### PR TITLE
Add sampctl support

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -1,7 +1,6 @@
 {
 	"user": "openmultiplayer",
 	"repo": "server-beta",
-    "include_path": "omp.inc",
 	"dependencies": [
 		"sampctl/samp-stdlib"
 	]

--- a/pawn.json
+++ b/pawn.json
@@ -1,0 +1,8 @@
+{
+	"user": "openmultiplayer",
+	"repo": "server-beta",
+    "include_path": "omp.inc",
+	"dependencies": [
+		"sampctl/samp-stdlib"
+	]
+}


### PR DESCRIPTION
Since omp.inc have been moved to server-beta, it's best to add pawn.json for sampctl support.